### PR TITLE
Fix bug in hull

### DIFF
--- a/recipes/Python/576816_Interval/recipe-576816.py
+++ b/recipes/Python/576816_Interval/recipe-576816.py
@@ -55,9 +55,7 @@ class Interval(object):
 
     def hull(self, other):
         "@return: Interval containing both self and other."
-        if self > other:
-            other, self = self, other
-        return Interval(self.start, other.end)
+        return Interval(min(self.start, other.start), max(self.end, other.end))
     
 
     def overlap(self, other):


### PR DESCRIPTION
Without this fix, `Interval.hull` returns the wrong result when one interval is completely contained in the other. I think the new code is more obvious too.

    Interval(4, 7).hull(Interval(5, 6))

returns

    Interval(4, 6)

not the correct answer of

    Interval(4, 7)